### PR TITLE
adding binary that automatically sets the full icu

### DIFF
--- a/node-full-icu.js
+++ b/node-full-icu.js
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+const { spawn } = require('child_process')
+const data = require('./full-icu')
+const env = data.icu_small ? {
+  ...process.env,
+  NODE_ICU_DATA: data.datPath()
+} : process.env
+
+spawn('/usr/bin/env', ['node', ...process.argv.slice(2)], { env, stdio: 'inherit' })

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "icu4c"
   ],
   "bin": {
+    "full-icu": "./node-full-icu.js",
     "node-full-icu-path": "./node-icu-data.js"
   },
   "main": "full-icu.js",


### PR DESCRIPTION
In a CI process it can be rather tricky to get node to use full icu. This PR adds a binary that starts directly with the icu data file if necessary which should make many processes a lot simpler.