### PR TITLE
Update package.json license to MIT

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "main": "full-icu.js",
   "author": "Steven R. Loomis <srl295@gmail.com>",
-  "license": "Unicode-DFS-2016",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/icu-project/full-icu-npm.git"


### PR DESCRIPTION
Fixes: #73 

is `"license": "MIT"` correct for Node.js licensed code? I assume so