### PR TITLE
chore: setup Dependabot for version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: '/'
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 99
+
+  - package-ecosystem: github-actions
+    directory: '/'
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 99

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,10 @@
 name: Lint
 
-on: [push, pull_request]
+on:
+  push:
+    branches-ignore:
+      - 'dependabot/**'
+  pull_request:
 
 jobs:
   lint:

--- a/.github/workflows/test-gh.yml
+++ b/.github/workflows/test-gh.yml
@@ -1,6 +1,10 @@
 name: Integration Test GitHub
 
-on: [push, pull_request]
+on:
+  push:
+    branches-ignore:
+      - 'dependabot/**'
+  pull_request:
 
 jobs:
   build:

--- a/.github/workflows/test-npm.yml
+++ b/.github/workflows/test-npm.yml
@@ -1,6 +1,10 @@
 name: Integration Test npm
 
-on: [push, pull_request]
+on:
+  push:
+    branches-ignore:
+      - 'dependabot/**'
+  pull_request:
 
 jobs:
   build:


### PR DESCRIPTION
There are other CI cleanups needed, but this should at least start opening PRs to update the actions and some of the devDeps