### PR TITLE
chore: cleanup ESLint deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.5.1-0",
   "description": "install 'full-icu' data for your current node",
   "scripts": {
-    "lint": "standard && eslint *.js test/*.js",
+    "lint": "eslint .",
     "postinstall": "node postinstall.js",
     "test": "tap test/*.js"
   },
@@ -29,12 +29,7 @@
   },
   "devDependencies": {
     "eslint": "^8.44.0",
-    "eslint-config-standard": "^16.0.3",
-    "eslint-plugin-header": "^3.0.0",
-    "eslint-plugin-import": "^2.24.2",
-    "eslint-plugin-node": "^11.1.0",
-    "eslint-plugin-promise": "^6.1.1",
-    "standard": "^16.0.3",
+    "eslint-config-standard": "^17.1.0",
     "tap": "^16.3.4"
   }
 }


### PR DESCRIPTION
Drops the extra plugins that aren't directly referenced in the config, and bump to ESLint v8