### PR TITLE
fix: use dots in release tag and filename for ICU >= 78

### DIFF
--- a/install-gh-data.js
+++ b/install-gh-data.js
@@ -21,12 +21,13 @@ module.exports = async function installFromGithub (fullIcu, advice) {
   const _baseUrl = process.env.FULL_ICU_BASEURL || 'https://github.com/unicode-org/icu/releases/'
   const baseUrl = new URL(_baseUrl)
   const versionsAsHyphen = fullIcu.icuver.replace(/\./g, '-')
-  // ICU v67/v68 use "68.1" and "67.1" in the filename instead of 68_1 and 69_1
+  // ICU v67/v68 use "68.1" and "67.1" in the filename instead of 68_1 and 67_1
+  // ICU v69-v77 use underscores in the filename and hyphens in the tag
+  // ICU >= v78 reverted to dots in both the release tag and filename
   // https://unicode-org.atlassian.net/browse/ICU-21764
-  // Can remove this conditional if the files are updated later.
-  const versionsAsUnderscore = (fullIcu.icumaj >= 69) ? fullIcu.icuver.replace(/\./g, '_') : fullIcu.icuver
-  const tag = `release-${versionsAsHyphen}`
-  const file = `icu4c-${versionsAsUnderscore}-data-bin-${icuend}.zip`
+  const versionInFilename = (fullIcu.icumaj >= 78) ? fullIcu.icuver : (fullIcu.icumaj >= 69) ? fullIcu.icuver.replace(/\./g, '_') : fullIcu.icuver
+  const tag = (fullIcu.icumaj >= 78) ? `release-${fullIcu.icuver}` : `release-${versionsAsHyphen}`
+  const file = `icu4c-${versionInFilename}-data-bin-${icuend}.zip`
   const fullUrl = new URL(`./download/${tag}/${file}`, baseUrl)
   console.log(fullUrl.toString())
   const [srcZip, tmpd] = await myFetch(fullUrl)


### PR DESCRIPTION
Starting from ICU 78.1, the unicode-org/icu GitHub releases reverted to using dots in both the release tag (release-78.1) and the filename (icu4c-78.1-data-bin-l.zip), instead of hyphens/underscores used in versions 69-77.

URL format by version range:
- v67-v68: release-67-1/icu4c-67.1-data-bin-l.zip (hyphens in tag, dots in file)
- v69-v77: release-73-1/icu4c-73_1-data-bin-l.zip (hyphens in tag, underscores in file)
- v78+:    release-78.1/icu4c-78.1-data-bin-l.zip (dots in both)
